### PR TITLE
Ensure remote path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ A GitHub Action that send the build file to a remote server for deployment via s
 
 **Required** Remote server private key, use `\n` to escape line breaks.
 
+### `ensureRemote`
+
+**Optional** Ensure the existance of the remote file path
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Remote server private key'
     required: true
 
+  ensureRemote:
+    description: 'Ensure the existance of the remote file path'
+    required: false
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,8 @@ echo -e "${INPUT_KEY}" >__TEMP_INPUT_KEY_FILE
 
 chmod 600 __TEMP_INPUT_KEY_FILE
 
+if [[ -z "${INPUT_ENSUREREMOTE}" ]]; then
+  ssh -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -p "${INPUT_PORT}" "${INPUT_USER}"@"${INPUT_HOST}" "mkdir -p ${INPUT_REMOTE}"
+fi
+
 scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "${INPUT_PORT}" -r ${INPUT_LOCAL} "${INPUT_USER}"@"${INPUT_HOST}":"${INPUT_REMOTE}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ echo -e "${INPUT_KEY}" >__TEMP_INPUT_KEY_FILE
 
 chmod 600 __TEMP_INPUT_KEY_FILE
 
-if [[ -z "${INPUT_ENSUREREMOTE}" ]]; then
+if test -n "${INPUT_ENSUREREMOTE}"; then
   ssh -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -p "${INPUT_PORT}" "${INPUT_USER}"@"${INPUT_HOST}" "mkdir -p ${INPUT_REMOTE}"
 fi
 


### PR DESCRIPTION
Started using this action for builds on Raspberry Pi's.

Just noticed that SCP only worked because they always took the longest to build. So the output directories were created by other systems.

They failed yesterday because the other systems didn't run.

Here is a patch to include an `ensureRemote` option.